### PR TITLE
Remove call to java 9+ method

### DIFF
--- a/src/main/java/com/ekotrope/maven/CodeArtifactWagon.java
+++ b/src/main/java/com/ekotrope/maven/CodeArtifactWagon.java
@@ -65,7 +65,7 @@ public class CodeArtifactWagon extends HttpWagon
         return codeartifact.getAuthorizationToken(new GetAuthorizationTokenRequest()
                 .withDomain(domain)
                 .withDomainOwner(owner)
-                .withDurationSeconds(Duration.of(8, HOURS).toSeconds())
+                .withDurationSeconds(Duration.of(8, HOURS).getSeconds())
             ).getAuthorizationToken();
     }
 


### PR DESCRIPTION
`Duration.toSeconds()` is marked as "since java 9+". In the docs for java 8, there is no `toSeconds()` method. There is however a `getSeconds()` method which does the same thing. I guess they added `toSeconds()` in java 9 for consistency and readability in the API.

I would have expected maven to complain about this, since we are setting the compiler version to java 8 in this project. Perhaps this is more an issue of which libraries are available rather than what the compiler is capable of, since `toSeconds()` does not appear to utilize any of the new features of java 9.

Relevant docs: [java8](https://docs.oracle.com/javase/8/docs/api/java/time/Duration.html) | [java9](https://docs.oracle.com/javase/9/docs/api/java/time/Duration.html)